### PR TITLE
Add missing locale to createI18n example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export const locale = localeFrom(
 
 export const format = formatter(locale)
 
-export const i18n = createI18n({
+export const i18n = createI18n(format, {
   get (code) {
     return fetchJSON(`/translations/${code}.json`)
   }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export const locale = localeFrom(
 
 export const format = formatter(locale)
 
-export const i18n = createI18n(format, {
+export const i18n = createI18n(locale, {
   get (code) {
     return fetchJSON(`/translations/${code}.json`)
   }


### PR DESCRIPTION
If I understood API and example right, locale is mandatory for `createI18n` function