### PR TITLE
fix: 🧪 TypeScript comments

### DIFF
--- a/browser/index.test.ts
+++ b/browser/index.test.ts
@@ -4,12 +4,12 @@ import { test } from 'uvu'
 import { browser } from '../index.js'
 
 function setLanguages(languages: string[]): void {
-  // @ts-ignore
+  // @ts-expect-error
   global.navigator = { languages }
 }
 
 test.after.each(() => {
-  // @ts-ignore
+  // @ts-expect-error
   delete global.navigator
 })
 
@@ -32,7 +32,7 @@ test('returns fallback on no matches', () => {
 })
 
 test('is ready for lack of languages support', () => {
-  // @ts-ignore
+  // @ts-expect-error
   global.navigator = { language: 'fr' }
   equal(browser({ available: ['fr', 'pt', 'en'] as const }).get(), 'fr')
 })

--- a/count/index.d.ts
+++ b/count/index.d.ts
@@ -32,6 +32,6 @@ export function count<Input extends CountInput>(
   input: Input
 ): TranslationFunction<
   [number],
-  // @ts-ignore
+  // @ts-expect-error
   Input[keyof Input]
 >

--- a/processor/index.d.ts
+++ b/processor/index.d.ts
@@ -4,11 +4,9 @@ import { TranslationJSON, TranslationFunction } from '../create-i18n/index.js'
 
 export interface Processor<Key extends string = string> {
   from: ReadableAtom<Key>
-  (input: Record<Key, TranslationJSON>): TranslationFunction<
-    [],
-    // @ts-ignore
-    Input[keyof Input]
-  >
+  <Input extends Record<Key, TranslationJSON>>(
+    input: Input
+  ): TranslationFunction<[], Input[keyof Input]>
 }
 
 /**


### PR DESCRIPTION
Summary of changes:

1. Removed all `// @ts-ignore` comments
2. Fixed one `// @ts-expect-error` comment (with `Input`)