### PR TITLE
Fix LocaleStore type

### DIFF
--- a/locale-from/index.d.ts
+++ b/locale-from/index.d.ts
@@ -1,6 +1,6 @@
-import { ReadableAtom, Atom } from 'nanostores'
+import { WritableAtom, Atom } from 'nanostores'
 
-export type LocaleStore<Locale extends string = string> = ReadableAtom<Locale>
+export type LocaleStore<Locale extends string = string> = WritableAtom<Locale>
 
 /**
  * Choose the first available locale from difference sources. Like use locale


### PR DESCRIPTION
Looks like `LocaleStore` is `WritableAtom` with `set` function.

```ts
import { createI18n, localeFrom, browser, formatter } from '@nanostores/i18n'
import { persistentAtom } from '@nanostores/persistent'

let availableLanguages: string[] = ['en', 'ru']

export let localeSettings = persistentAtom<string>('PROJECT_LANGUAGE')

export let locale = localeFrom(
  localeSettings,
  browser({
    available: availableLanguages,
    fallback: 'en',
  }),
)

console.log('locale', locale)
```

<img width="477" alt="Screen Shot 2022-10-26 at 1 56 28 AM" src="https://user-images.githubusercontent.com/5698350/197897851-dc83f781-63ff-4fff-92a8-8040606d10b8.png">
