### PR TITLE
WIP: fix potential wrong language on first use

### DIFF
--- a/create-i18n/index.js
+++ b/create-i18n/index.js
@@ -45,7 +45,7 @@ export function createI18n(locale, opts) {
     function setTranslation(code) {
       let translations = {
         ...define.cache[baseLocale][componentName],
-        ...define.cache[code][componentName]
+        ...define.cache[code]?.[componentName]
       }
       for (let i in transforms) {
         let nodeTransform = transforms[i]
@@ -54,7 +54,7 @@ export function createI18n(locale, opts) {
       }
       t.set(translations)
     }
-    setTranslation(baseLocale)
+    setTranslation(locale.get())
 
     onMount(t, () => {
       mounted.add(componentName)

--- a/create-i18n/index.test.ts
+++ b/create-i18n/index.test.ts
@@ -245,4 +245,17 @@ test('tracks double definition', () => {
   match(warn.calls[0][0], /defined multiple times/)
 })
 
+test("cache is used on first use", async () => {
+  let locale = atom('ru')
+  let i18nWithCache = createI18n(locale, {
+    get,
+    cache: {
+      ru: { games: { title: 'Игры' } },
+    },
+  })
+  let gamesWithCache = i18nWithCache('games', { title: 'Games' })
+  // @ts-ignore: can be removed after release of https://github.com/nanostores/nanostores/commit/d2fa758
+  equal(gamesWithCache.value.title, 'Игры')
+})
+
 test.run()

--- a/package.json
+++ b/package.json
@@ -96,12 +96,12 @@
     {
       "name": "Minimum",
       "import": "{ localeFrom, createI18n }",
-      "limit": "654 B"
+      "limit": "658 B"
     },
     {
       "name": "Maximum",
       "import": "{ localeFrom, browser, createI18n, params, count, formatter, createProcessor }",
-      "limit": "1088 B"
+      "limit": "1091 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Currently, when first used, the baseLocale is always used. This results in the initial rendering being done with the baseLocale, but then immediately followed by a re-rendering with the current locale. This is unpleasant but not critical on the client side. However, when using SSR (Server-Side Rendering), this leads to the page being generated with the baseLocale regardless of the chosen language.

UPD: It seems that fixing this I broke something else. I'll take a little more time. 

UPD2: I will also add a test for my problem.

UPD3: this is my local problem, due to the fact that I do not use the [problematic implementation of nanostores/react](https://github.com/nanostores/react/issues/17). If that problem is solved in the proposed way, then this PR will be useful, for now it should be left as WIP.