### PR TITLE
Added extracting of templated params from `params`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ import { i18n, format } from '../stores/i18n.js'
 
 export const messages = i18n('post', {
   title: 'Post details',
-  // You need to manually mark interpolation like {at} for better TS support
-  published: params<{ at: string }>('Was published at {at}'),
+  published: params('Was published at {at}'),
   comments: count({
     one: '{count} comment',
     many: '{count} comments'
@@ -264,7 +263,7 @@ for TypeScript types and translation functions (`count()`, `params()`, etc).
 ```ts
 export const messages = i18n('post', {
   title: 'Post details',
-  published: params<{ at: string }>('Was published at {at}'),
+  published: params('Was published at {at}'),
   comments: count({
     one: '{count} comment',
     many: '{count} comments'
@@ -303,7 +302,7 @@ import { params } from '@nanostores/i18n'
 import { i18n } from '../stores/i18n.js'
 
 export const messages = i18n('hi', {
-  hello: params<{ name: string }>('Hello, {name}')
+  hello: params('Hello, {name}')
 })
 
 export const Robots = ({ name }) => {
@@ -316,6 +315,26 @@ You can use `time()` and `number()` [formatting functions].
 
 [formatting functions]: https://github.com/nanostores/i18n/#date--number-format
 
+And you can also use the [`count()`](https://github.com/nanostores/i18n#pluralization) function:
+
+```ts
+import { count, params } from '@nanostores/i18n'
+import { i18n } from '../stores/i18n'
+
+export const messages = i18n('pagination', {
+  page: params<{ category: string }>(
+    count({
+      one: 'One page in {category}',
+      many: '{count} pages in {category}'
+    })
+  )
+})
+
+export const RobotsListInfo = ({ count }) => {
+  const t = useStore(messages)
+  return t.page({ category: 'robots' })(count)
+}
+```
 
 #### Pluralization
 

--- a/create-i18n/errors.ts
+++ b/create-i18n/errors.ts
@@ -41,9 +41,9 @@ let messages = i18n('post', {
 console.log(messages.get().title2)
 
 let messages2 = i18n('post', {
-  title: params<{ name: string }>('Title: {name}')
+  title: params('Title: {name}')
 })
-// THROWS to parameter of type '{ name: string; }
+// THROWS to parameter of type '{ name: string | number; }
 testString(messages2.get().title({ named: 'Post' }))
 // THROWS is not assignable to parameter of type 'string'
 testString(messages2.get().title)

--- a/create-i18n/types.ts
+++ b/create-i18n/types.ts
@@ -33,7 +33,7 @@ let i18n2 = createI18n(locale, {
 })
 
 let messages2 = i18n2('post', {
-  title: params<{ name: string }>('Title: {name}'),
+  title: params('Title: {name}'),
   posts: count({
     one: '1 post',
     many: '{count} posts'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "unit": "tsm node_modules/uvu/bin.js . '\\.test\\.(ts|js)$'",
-    "test": "c8 yarn unit && eslint . && check-dts && size-limit",
+    "test": "c8 yarn unit && eslint . --report-unused-disable-directives && check-dts && size-limit",
     "start": "vite demo/"
   },
   "author": "Andrey Sitnik <andrey@sitnik.ru>",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "unit": "tsm node_modules/uvu/bin.js . '\\.test\\.(ts|js)$'",
-    "test": "c8 yarn unit && eslint . --report-unused-disable-directives && check-dts && size-limit",
+    "test": "c8 yarn unit && eslint . && check-dts && size-limit",
     "start": "vite demo/"
   },
   "author": "Andrey Sitnik <andrey@sitnik.ru>",

--- a/params/index.d.ts
+++ b/params/index.d.ts
@@ -3,6 +3,12 @@ import type {
   TranslationFunction
 } from '../create-i18n/index.js'
 
+type ExtractTemplateParams<Str extends string> =
+  Str extends `${infer Pre}{${infer Param}}${infer Post}`
+    ? { [key in Param]: string | number } & ExtractTemplateParams<Pre> &
+        ExtractTemplateParams<Post>
+    : {}
+
 interface Params {
   /**
    * Add `{name}` parameters to translation strings.
@@ -24,6 +30,12 @@ interface Params {
    * @param input Template string.
    * @return Transform for translation.
    */
+  <Input extends string>(input: Input): TranslationFunction<
+    keyof ExtractTemplateParams<Input> extends never
+      ? []
+      : [ExtractTemplateParams<Input>],
+    string
+  >
   <Parameters extends Record<string, string | number>>(
     input: string
   ): TranslationFunction<[Parameters], string>

--- a/params/index.d.ts
+++ b/params/index.d.ts
@@ -18,7 +18,7 @@ interface Params {
    * import { i18n } from '../stores/i18n'
    *
    * export const messages = i18n('pagination', {
-   *   page: params<{ page: number, all: numbers }>('Page {page} from {all}')
+   *   page: params('Page {page} from {all}')
    * })
    * ```
    *
@@ -27,7 +27,7 @@ interface Params {
    * t.page({ page: 1, all: 10 })
    * ```
    *
-   * @param input Template string.
+   * @param input Template string or `TranslationFunction`.
    * @return Transform for translation.
    */
   <Input extends string>(input: Input): TranslationFunction<

--- a/params/index.test.ts
+++ b/params/index.test.ts
@@ -11,10 +11,19 @@ let i18n = createI18n(locale, {
 
 test('replaces templates', () => {
   let messages = i18n('templates', {
-    multiple: params<{ one: number; two: number }>('{one} {one} {two}')
+    multiple: params('{one} {one} {two}'),
+    noParams: params('no params'),
+    doubleEscaped1: params<{ '{param}': 1 }>('{{param}}'),
+    doubleEscaped2: params<{ param: 1 }>('{{param}}')
   })
   equal(messages.get().multiple({ one: 1, two: 2 }), '1 1 2')
   equal((messages as any).value.multiple({ one: 1, two: 2 }), '1 1 2')
+  equal(messages.get().noParams(), 'no params')
+  equal((messages as any).value.noParams(), 'no params')
+  equal(messages.get().doubleEscaped1({ '{param}': 1 }), '1')
+  equal((messages as any).value.doubleEscaped1({ '{param}': 1 }), '1')
+  equal(messages.get().doubleEscaped2({ param: 1 }), '{1}')
+  equal((messages as any).value.doubleEscaped2({ param: 1 }), '{1}')
 })
 
 test.run()

--- a/params/types.ts
+++ b/params/types.ts
@@ -15,7 +15,9 @@ const f2 = params<{ category: number }>(
 )
 const f21 = f2({ category: 12 })
 const f22 = f2(12)
-const incorrectParamsType = params<{ categor: number }>('Pages in {category}')
+const incorrectParamsType = params<{ incorrect_param: number }>(
+  'Pages in {category}'
+)
 const noParams = params('No params')
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -48,7 +50,7 @@ type cases = [
   Assert<
     IsExact<
       typeof incorrectParamsType,
-      TranslationFunction<[{ categor: number }], any>
+      TranslationFunction<[{ incorrect_param: number }], any>
     >
   >,
   Assert<IsExact<typeof noParams, TranslationFunction<[], string>>>,

--- a/params/types.ts
+++ b/params/types.ts
@@ -1,12 +1,12 @@
 import type { AssertTrue as Assert, IsExact } from 'conditional-type-checks'
 import type { TranslationFunction } from '../create-i18n'
+import type { ExtractTemplateParams } from '.'
 
 import { params } from '.'
 // eslint-disable-next-line import/extensions
 import { count } from '../count'
-// eslint-disable-next-line import/extensions
 
-const f1 = params<{ category: number }>('Pages in {category}')
+const f1 = params('Pages in {category}')
 const f2 = params<{ category: number }>(
   count({
     one: 'One page in {category}',
@@ -15,11 +15,16 @@ const f2 = params<{ category: number }>(
 )
 const f21 = f2({ category: 12 })
 const f22 = f2(12)
+const incorrectParamsType = params<{ categor: number }>('Pages in {category}')
+const noParams = params('No params')
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type cases = [
   Assert<
-    IsExact<typeof f1, TranslationFunction<[{ category: number }], string>>
+    IsExact<
+      typeof f1,
+      TranslationFunction<[{ category: string | number }], string>
+    >
   >,
   Assert<IsExact<ReturnType<typeof f1>, string>>,
   Assert<
@@ -39,5 +44,41 @@ type cases = [
   // 1. Parameters
   Assert<IsExact<Parameters<typeof f2>, [input: { category: number }]>>,
   // 2. ReturnType
-  Assert<IsExact<ReturnType<typeof f2>, TranslationFunction<[number], string>>>
+  Assert<IsExact<ReturnType<typeof f2>, TranslationFunction<[number], string>>>,
+  Assert<
+    IsExact<
+      typeof incorrectParamsType,
+      TranslationFunction<[{ categor: number }], any>
+    >
+  >,
+  Assert<IsExact<typeof noParams, TranslationFunction<[], string>>>,
+  // Cases for `ExtractTemplateParams`
+  Assert<
+    IsExact<
+      ExtractTemplateParams<'test {param_1} {param_2}'>,
+      { param_1: string | number; param_2: string | number }
+    >
+  >,
+  Assert<
+    IsExact<
+      ExtractTemplateParams<'{param_1} {param_2}'>,
+      { param_1: string | number; param_2: string | number }
+    >
+  >,
+  Assert<
+    IsExact<ExtractTemplateParams<'{param_1}'>, { param_1: string | number }>
+  >,
+  Assert<IsExact<ExtractTemplateParams<'test'>, {}>>,
+  Assert<
+    IsExact<
+      ExtractTemplateParams<'{param_1} test'>,
+      { param_1: string | number }
+    >
+  >,
+  Assert<
+    IsExact<
+      ExtractTemplateParams<'{param_1} {param_2} test'>,
+      { param_1: string | number; param_2: string | number }
+    >
+  >
 ]


### PR DESCRIPTION
Close #34 

Hi! This pull request solves the problem of autoinferring parameters for the `params` function, but with two edge cases:
1. If nested templates are used (see example in test file), we can't be sure which of the parameter names will be used. Therefore, for this case, it remains possible to set parameters in the function.
2. The case of using functions as parameters, for example, the `count` function, is not processed here. This requires an extension of the return type signature of the `TranslationFunction` function (even if it will be readable), and will likely require updating the types of all utilities.