### PR TITLE
fix: expose i18n on messages in production

### DIFF
--- a/create-i18n/index.js
+++ b/create-i18n/index.js
@@ -60,9 +60,9 @@ export function createI18n(locale, opts) {
     }
 
     let t = atom()
+    t.i18n = define
 
     if (process.env.NODE_ENV !== 'production') {
-      t.i18n = define
       t.base = base
       t.component = componentName
       if (define.cache[baseLocale][componentName]) {

--- a/package.json
+++ b/package.json
@@ -66,12 +66,12 @@
     {
       "name": "Minimum",
       "import": "{ localeFrom, createI18n }",
-      "limit": "652 B"
+      "limit": "674 B"
     },
     {
       "name": "Maximum",
       "import": "{ localeFrom, browser, createI18n, params, count, formatter, createProcessor }",
-      "limit": "1056 B"
+      "limit": "1065 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
Quick fix for loadTranslations. 
i18n object must be exposed in `NODE_ENV === 'production'`, otherwise `translationsLoading` called inside of `loadTranslations` helper fails.

```
⨯ TypeError: Cannot read properties of undefined (reading 'loading')
    at <unknown> (.next/server/chunks/ssr/_042pc4w._.js:1:91)
    at c (.next/server/chunks/ssr/_042pc4w._.js:3:6748)
    at I (.next/server/chunks/ssr/_0rtv8r-._.js:1:19323) {
  digest: '2416329503'
}
```

I have immediately noticed it after deploying to vercel.