### PR TITLE
implement additional plural rules for count function

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ export const messages = i18n('post', {
   published: params('Was published at {at}'),
   comments: count({
     one: '{count} comment',
-    many: '{count} comments'
+    other: '{count} comments'
   })
 })
 ```
@@ -335,7 +335,7 @@ export const messages = i18n('pagination', {
   page: params<{ category: string }>(
     count({
       one: 'One page in {category}',
-      many: '{count} pages in {category}'
+      other: '{count} pages in {category}'
     })
   )
 })
@@ -350,7 +350,7 @@ export const RobotsListInfo = ({ count }) => {
 
 In many languages, text could be different depends on items count.
 Compare `1 robot`/`2 robots` in English with
-`1 робот`/`2 робота`/`3 робота`/`21 робот` in Russian.
+`1 robot`/`2 roboty`/`2.5 robota`/`10 robotów` in Polish.
 
 We hide this complexity with `count()` translation transform:
 
@@ -362,7 +362,7 @@ import { i18n } from '../stores/i18n.js'
 export const messages = i18n('robots', {
   howMany: count({
     one: '{count} robot',
-    many: '{count} robots'
+    other: '{count} robots'
   })
 })
 
@@ -376,9 +376,10 @@ export const Robots = ({ robots }) => {
 {
   "robots": {
     "howMany": {
-      "one": "{count} робот",
-      "few": "{count} робота",
-      "many": "{count} роботов"
+      "one": "{count} robot",
+      "few": "{count} roboty",
+      "many": "{count} robotów",
+      "other": "{count} robota"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export const messages = i18n('post', {
   published: params('Was published at {at}'), // TypeScript will get `at` type
   comments: count({
     one: '{count} comment',
-    many: '{count} comments'
+    other: '{count} comments'
   })
 })
 

--- a/count/index.d.ts
+++ b/count/index.d.ts
@@ -4,11 +4,23 @@ import type {
   TranslationJSON
 } from '../create-i18n/index.js'
 
-export type CountInput = {
-  few?: TranslationJSON
-  many: TranslationJSON
-  one?: TranslationJSON
-}
+export type CountInput =
+  | {
+      zero?: TranslationJSON
+      one?: TranslationJSON
+      two?: TranslationJSON
+      few?: TranslationJSON
+      many: TranslationJSON
+      other?: TranslationJSON
+    }
+  | {
+      zero?: TranslationJSON
+      one?: TranslationJSON
+      two?: TranslationJSON
+      few?: TranslationJSON
+      many?: TranslationJSON
+      other: TranslationJSON
+    }
 
 interface Count {
   /**
@@ -21,7 +33,7 @@ interface Count {
    * export const messages = i18n('pagination', {
    *   pages: count({
    *     one: 'One page',
-   *     many: '{count} pages'
+   *     other: '{count} pages'
    *   })
    * })
    * ```

--- a/count/index.js
+++ b/count/index.js
@@ -2,6 +2,10 @@ import { strings, transform } from '../transforms/index.js'
 
 export const count = transform((locale, translation, num) => {
   let form = new Intl.PluralRules(locale).select(num)
-  if (!(form in translation)) form = 'many'
+  if (!(form in translation)) {
+    if ('other' in translation) form = 'other'
+    else form = 'many'
+  }
+
   return strings(translation[form], str => str.replace(/{count}/g, num))
 })

--- a/count/index.js
+++ b/count/index.js
@@ -2,10 +2,7 @@ import { strings, transform } from '../transforms/index.js'
 
 export const count = transform((locale, translation, num) => {
   let form = new Intl.PluralRules(locale).select(num)
-  if (!(form in translation)) {
-    if ('other' in translation) form = 'other'
-    else form = 'many'
-  }
+  if (!(form in translation)) form = 'other' in translation ? 'other' : 'many'
 
   return strings(translation[form], str => str.replace(/{count}/g, num))
 })

--- a/count/index.test.ts
+++ b/count/index.test.ts
@@ -18,7 +18,7 @@ function getResponse(translations: ComponentsJSON): Promise<void> {
   return Promise.resolve()
 }
 
-let locale = atom('ru')
+let locale = atom('pl')
 let i18n = createI18n(locale, { get })
 
 test('uses pluralization rules', async () => {
@@ -26,8 +26,11 @@ test('uses pluralization rules', async () => {
     onlyMany: count({
       many: 'many'
     }),
+    onlyOther: count({
+      other: 'other'
+    }),
     robots: count({
-      many: '{count} robots',
+      other: '{count} robots',
       one: '{count} robot'
     })
   })
@@ -37,21 +40,29 @@ test('uses pluralization rules', async () => {
   await getResponse({
     templates: {
       onlyMany: {
-        many: 'много'
+        many: 'wiele'
+      },
+      onlyOther: {
+        other: 'inne'
       },
       robots: {
-        few: '{count} робота',
-        many: '{count} роботов',
-        one: '{count} робот'
+        one: '{count} robot',
+        few: '{count} roboty',
+        many: '{count} robotów',
+        other: '{count} robota'
       }
     }
   })
 
-  equal(messages.get().robots(1), '1 робот')
-  equal(messages.get().robots(21), '21 робот')
-  equal(messages.get().robots(2), '2 робота')
-  equal(messages.get().robots(5), '5 роботов')
+  equal(messages.get().robots(0), '0 robotów')
+  equal(messages.get().robots(1), '1 robot')
+  equal(messages.get().robots(2), '2 roboty')
+  equal(messages.get().robots(5), '5 robotów')
+  equal(messages.get().robots(2.5), '2.5 robota')
 
-  equal(messages.get().onlyMany(1), 'много')
-  equal(messages.get().onlyMany(2), 'много')
+  equal(messages.get().onlyMany(1), 'wiele')
+  equal(messages.get().onlyMany(2), 'wiele')
+
+  equal(messages.get().onlyOther(1), 'inne')
+  equal(messages.get().onlyOther(2), 'inne')
 })

--- a/count/index.test.ts
+++ b/count/index.test.ts
@@ -18,7 +18,7 @@ function getResponse(translations: ComponentsJSON): Promise<void> {
   return Promise.resolve()
 }
 
-let locale = atom('pl')
+let locale = atom<'ru' | 'pl'>('ru')
 let i18n = createI18n(locale, { get })
 
 test('uses pluralization rules', async () => {
@@ -36,6 +36,29 @@ test('uses pluralization rules', async () => {
   })
 
   messages.subscribe(() => {})
+
+  await getResponse({
+    templates: {
+      onlyMany: {
+        many: 'много'
+      },
+      robots: {
+        few: '{count} робота',
+        many: '{count} роботов',
+        one: '{count} робот'
+      }
+    }
+  })
+
+  equal(messages.get().robots(1), '1 робот')
+  equal(messages.get().robots(21), '21 робот')
+  equal(messages.get().robots(2), '2 робота')
+  equal(messages.get().robots(5), '5 роботов')
+
+  equal(messages.get().onlyMany(1), 'много')
+  equal(messages.get().onlyMany(2), 'много')
+
+  locale.set('pl')
 
   await getResponse({
     templates: {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     {
       "name": "Maximum",
       "import": "{ localeFrom, browser, createI18n, params, count, formatter, createProcessor }",
-      "limit": "1081 B"
+      "limit": "1077 B"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     {
       "name": "Maximum",
       "import": "{ localeFrom, browser, createI18n, params, count, formatter, createProcessor }",
-      "limit": "1065 B"
+      "limit": "1081 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
I extended typing of plural rules in `count` method to cover cases from many other languages i.e., `"other"` in Polish and English, `"zero"` and `"two"` in Arabic.

Right now `count` requires one of `many` or `other` keys with `other` taking precedence over `many` in case of missing key.

I also adjusted English examples to use the correct `other` key as returned by `Intl.PluralRules`.
```typescript
const rules = new Intl.PluralRules('en')

rules.select(1) // "one"
rules.select(5) // "other"
```